### PR TITLE
Custom casing everywhere

### DIFF
--- a/crates/tighterror-build/src/coder/generator/module.rs
+++ b/crates/tighterror-build/src/coder/generator/module.rs
@@ -188,14 +188,14 @@ impl<'a> ModuleGenerator<'a> {
     fn private_category_error_names(&self, c: &CategorySpec) -> TokenStream {
         let cat_mod_ident = format_ident!("{}", c.kinds_module_name());
         let const_iter = c.errors.iter().map(|e| {
-            let ident = e.ident_name();
-            let const_ident = format_ident!("{}", ident);
+            let name = e.name.as_str();
+            let const_ident = format_ident!("{}", name);
             quote! {
-                const #const_ident: &str = #ident
+                const #const_ident: &str = #name
             }
         });
         let arr_iter = c.errors.iter().map(|e| {
-            let const_ident = format_ident!("{}", e.ident_name());
+            let const_ident = format_ident!("{}", e.name);
             quote! { #const_ident }
         });
         let n_errors = Literal::usize_unsuffixed(c.errors.len());
@@ -232,14 +232,14 @@ impl<'a> ModuleGenerator<'a> {
     fn private_category_error_display(&self, c: &CategorySpec) -> TokenStream {
         let cat_mod_ident = format_ident!("{}", c.kinds_module_name());
         let const_iter = c.errors.iter().map(|e| {
-            let const_ident = format_ident!("{}", e.ident_name());
+            let const_ident = format_ident!("{}", e.name);
             let display = self.module.err_kind_display(c, e);
             quote! {
                 const #const_ident: &str = #display
             }
         });
         let arr_iter = c.errors.iter().map(|e| {
-            let const_ident = format_ident!("{}", e.ident_name());
+            let const_ident = format_ident!("{}", e.name);
             quote! { #const_ident }
         });
         let n_errors = Literal::usize_unsuffixed(c.errors.len());
@@ -592,7 +592,7 @@ impl<'a> ModuleGenerator<'a> {
         for (i, e) in c.errors.iter().enumerate() {
             let cat_ident = format_ident!("{}", c.ident_name());
             let err_value = self.usize_to_repr_type_literal(i).unwrap();
-            let err_ident = format_ident!("{}", e.ident_name());
+            let err_ident = format_ident!("{}", e.name);
             let err_doc = doc_tokens(self.module.err_kind_const_doc(c, e));
             tokens = quote! {
                 #tokens
@@ -757,12 +757,12 @@ impl<'a> ModuleGenerator<'a> {
         let err_kinds_mod = err_kinds_mod_ident();
         let iter = self.module.categories.iter().map(|c| {
             let ec_iter = c.errors.iter().map(|e| {
-                let ident_name = e.ident_name();
+                let name = e.name.as_str();
                 let add_cat_mod = !self.module.flat_kinds();
                 let ident = self.err_const_tokens(c, e, add_cat_mod);
                 quote! {
-                    assert_eq!(#ident.name(), #ident_name);
-                    assert_eq!(tighterror::Kind::name(&#ident), #ident_name);
+                    assert_eq!(#ident.name(), #name);
+                    assert_eq!(tighterror::Kind::name(&#ident), #name);
                 }
             });
             quote! {
@@ -785,11 +785,11 @@ impl<'a> ModuleGenerator<'a> {
         let err_kinds_mod = err_kinds_mod_ident();
         let iter = self.module.categories.iter().map(|c| {
             let ec_iter = c.errors.iter().map(|e| {
-                let ident_name = e.ident_name();
+                let name = e.name.as_str();
                 let add_cat_mod = !self.module.flat_kinds();
                 let ident = self.err_const_tokens(c, e, add_cat_mod);
                 quote! {
-                    assert_eq!(format!("{}", #ident), #ident_name);
+                    assert_eq!(format!("{}", #ident), #name);
                 }
             });
             quote! {
@@ -908,9 +908,9 @@ impl<'a> ModuleGenerator<'a> {
                 let add_cat_mod = !self.module.flat_kinds();
                 let err_ident = self.err_const_tokens(c, e, add_cat_mod);
                 let display = if let Some(ref d) = e.display {
-                    d.clone()
+                    d.as_str()
                 } else {
-                    e.ident_name()
+                    e.name.as_str()
                 };
                 quote! {
                     assert_eq!(format!("{}", #err_name::from(#err_ident)), #display);
@@ -997,7 +997,7 @@ impl<'a> ModuleGenerator<'a> {
     }
 
     fn err_const_tokens(&self, c: &CategorySpec, e: &ErrorSpec, add_cat_mod: bool) -> TokenStream {
-        let err_ident = format_ident!("{}", e.ident_name());
+        let err_ident = format_ident!("{}", e.name);
         let cat_mod_ident = format_ident!("{}", c.kinds_module_name());
         if add_cat_mod {
             quote! {

--- a/crates/tighterror-build/src/common.rs
+++ b/crates/tighterror-build/src/common.rs
@@ -1,0 +1,1 @@
+pub mod casing;

--- a/crates/tighterror-build/src/common/casing.rs
+++ b/crates/tighterror-build/src/common/casing.rs
@@ -1,0 +1,33 @@
+use convert_case::{Case, Converter};
+
+pub fn convert_case(s: &str, from_case: Case, to_case: Case) -> String {
+    Converter::new()
+        .from_case(from_case)
+        .to_case(to_case)
+        .convert(s)
+}
+
+pub fn is_case(s: &str, case: Case) -> bool {
+    convert_case(s, case, case) == s
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+    use convert_case::Case::*;
+
+    #[test]
+    fn test_convert_case() {
+        let cases = &[
+            // str_to_convert, from_case, to_case, expected_result
+            ("MY_ERR1", UpperSnake, UpperSnake, "MY_ERR1"),
+            ("MyErr1", UpperSnake, UpperSnake, "MYERR1"),
+            ("MyErr1", UpperCamel, UpperSnake, "MY_ERR_1"),
+            ("MY_ERR1", UpperSnake, UpperCamel, "MyErr1"),
+        ];
+
+        for c in cases {
+            assert_eq!(convert_case(c.0, c.1, c.2), c.3);
+        }
+    }
+}

--- a/crates/tighterror-build/src/lib.rs
+++ b/crates/tighterror-build/src/lib.rs
@@ -133,6 +133,8 @@ pub const DEFAULT_SPEC_PATH_YAML: &str = "tighterror.yaml";
 #[cfg_attr(docsrs, doc(cfg(feature = "toml")))]
 pub const DEFAULT_SPEC_PATH_TOML: &str = "tighterror.toml";
 
+mod common;
+
 mod coder;
 pub use coder::*;
 

--- a/crates/tighterror-build/src/spec/category.rs
+++ b/crates/tighterror-build/src/spec/category.rs
@@ -1,8 +1,8 @@
-use crate::spec::{ErrorSpec, OverridableErrorSpec};
-use convert_case::{
-    Case::{Snake, UpperSnake},
-    Casing,
+use crate::{
+    common::casing,
+    spec::{ErrorSpec, OverridableErrorSpec},
 };
+use convert_case::Case::{Snake, UpperCamel, UpperSnake};
 
 pub const IMPLICIT_CATEGORY_NAME: &str = "General";
 
@@ -17,11 +17,11 @@ pub struct CategorySpec {
 
 impl CategorySpec {
     pub fn ident_name(&self) -> String {
-        self.name.to_case(UpperSnake)
+        casing::convert_case(&self.name, UpperCamel, UpperSnake)
     }
 
     pub fn kinds_module_name(&self) -> String {
-        self.name.to_case(Snake)
+        casing::convert_case(&self.name, UpperCamel, Snake)
     }
 
     pub fn implicit_with_errors(errors: Vec<ErrorSpec>) -> Self {

--- a/crates/tighterror-build/src/spec/error.rs
+++ b/crates/tighterror-build/src/spec/error.rs
@@ -1,5 +1,3 @@
-use convert_case::{Case::UpperSnake, Casing};
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OverridableErrorSpec {
     pub doc_from_display: Option<bool>,
@@ -11,10 +9,4 @@ pub struct ErrorSpec {
     pub display: Option<String>,
     pub doc: Option<String>,
     pub oes: OverridableErrorSpec,
-}
-
-impl ErrorSpec {
-    pub fn ident_name(&self) -> String {
-        self.name.to_case(UpperSnake)
-    }
 }

--- a/crates/tighterror-build/src/spec/module.rs
+++ b/crates/tighterror-build/src/spec/module.rs
@@ -100,11 +100,11 @@ impl ModuleSpec {
         }
     }
 
-    pub fn err_kind_display(&self, _c: &CategorySpec, e: &ErrorSpec) -> String {
+    pub fn err_kind_display<'e>(&self, _c: &CategorySpec, e: &'e ErrorSpec) -> &'e str {
         if let Some(dsp) = e.display.as_ref() {
-            return dsp.clone();
+            return dsp.as_str();
         }
-        e.ident_name()
+        e.name.as_str()
     }
 
     pub fn err_kind_doc(&self) -> &str {


### PR DESCRIPTION
Make sure our custom casing conversion primitive is used instead of the implicit `convert_case::Casing` implementation.

This way `convert_case::Converter` doesn't need to guess what is the source case.