### PR TITLE
tb: fix `clippy::manual_inspect` error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.74.0  # MSRV
+          - 1.76.0  # MSRV
         runs_on:
           - ubuntu-latest
           - macos-latest

--- a/crates/tighterror-build/src/coder/generator/bits.rs
+++ b/crates/tighterror-build/src/coder/generator/bits.rs
@@ -28,12 +28,11 @@ impl Bits {
         assert!(n_variant_bits > 0);
 
         let n_kind_bits = n_category_bits + n_variant_bits;
-        let repr_type = ReprType::from_n_bits(n_kind_bits).map_err(|e| {
+        let repr_type = ReprType::from_n_bits(n_kind_bits).inspect_err(|_| {
             let ltn = ReprType::largest_type_name();
             log::error!(
                 "not enough bits in largest supported underlying type {ltn}: {n_kind_bits}"
             );
-            e
         })?;
 
         assert!(n_category_bits < repr_type.bits());


### PR DESCRIPTION
Otherwise clippy fails in the new v1.81.0-beta.1 version with error:

error: using `map_err` over `inspect_err`
   --> crates/tighterror-build/src/coder/generator/bits.rs:31:60
    |
31  |         let repr_type = ReprType::from_n_bits(n_kind_bits).map_err(|e| {
    |                                                            ^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
note: the lint level is defined here
   --> crates/tighterror-build/src/lib.rs:122:9
    |
122 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::manual_inspect)]` implied by `#[deny(warnings)]`
help: try
    |
31  ~         let repr_type = ReprType::from_n_bits(n_kind_bits).inspect_err(|e| {
32  |             let ltn = ReprType::largest_type_name();
33  |             log::error!(
34  |                 "not enough bits in largest supported underlying type {ltn}: {n_kind_bits}"
35  ~             );
    |

error: could not compile `tighterror-build` (lib) due to 1 previous error