### PR TITLE
github: bump the MSRV from v1.74 to v1.76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.74.0  # MSRV
+          - 1.76.0  # MSRV
         runs_on:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
This is done in prepation for fixing `clippy::manual_inspect` error which appears now in v1.81.0-beta.1. The fix requires usage of `Result::inspect_err` which is available since v1.76.