### PR TITLE
tb: coding: change the way object attributes are iterated

### DIFF
--- a/crates/tighterror-build/src/parser/kws.rs
+++ b/crates/tighterror-build/src/parser/kws.rs
@@ -21,25 +21,8 @@ pub const CATEGORY: &str = "category";
 pub const CATEGORIES: &str = "categories";
 pub const FLAT_KINDS: &str = "flat_kinds";
 
-pub const ERR_KWS: [&str; 4] = [NAME, DISPLAY, DOC, DOC_FROM_DISPLAY];
 pub const CAT_KWS: [&str; 4] = [NAME, DOC, DOC_FROM_DISPLAY, ERRORS];
-pub const MODULE_KWS: [&str; 14] = [
-    CATEGORIES,
-    DOC_FROM_DISPLAY,
-    DOC,
-    ERR_CAT_DOC,
-    ERR_DOC,
-    ERR_KIND_DOC,
-    NAME,
-    RESULT_FROM_ERR,
-    RESULT_FROM_ERR_KIND,
-    ERROR_TRAIT,
-    ERR_NAME,
-    ERR_KIND_NAME,
-    ERR_CAT_NAME,
-    FLAT_KINDS,
-];
-pub const MAIN_KWS: [&str; 2] = [OUTPUT, NO_STD];
+
 pub const ROOT_KWS: [&str; 6] = [MAIN, ERRORS, MODULE, MODULES, CATEGORY, CATEGORIES];
 pub const REQUIRED_ROOT_KWS: [&str; 3] = [ERRORS, CATEGORIES, MODULES];
 pub const MUTUALLY_EXCLUSIVE_ROOT_KWS: [(&str, &str); 6] = [
@@ -88,20 +71,6 @@ pub fn is_any_kw(s: &str) -> bool {
 #[inline]
 pub fn is_root_kw(s: &str) -> bool {
     contains(&ROOT_KWS, s)
-}
-
-#[inline]
-pub fn is_err_kw(s: &str) -> bool {
-    contains(&ERR_KWS, s)
-}
-
-#[inline]
-pub fn is_mod_kw(s: &str) -> bool {
-    contains(&MODULE_KWS, s)
-}
-
-pub fn is_main_kw(s: &str) -> bool {
-    contains(&MAIN_KWS, s)
 }
 
 pub fn is_cat_kw(s: &str) -> bool {

--- a/crates/tighterror-build/src/parser/kws.rs
+++ b/crates/tighterror-build/src/parser/kws.rs
@@ -21,8 +21,6 @@ pub const CATEGORY: &str = "category";
 pub const CATEGORIES: &str = "categories";
 pub const FLAT_KINDS: &str = "flat_kinds";
 
-pub const CAT_KWS: [&str; 4] = [NAME, DOC, DOC_FROM_DISPLAY, ERRORS];
-
 pub const ROOT_KWS: [&str; 6] = [MAIN, ERRORS, MODULE, MODULES, CATEGORY, CATEGORIES];
 pub const REQUIRED_ROOT_KWS: [&str; 3] = [ERRORS, CATEGORIES, MODULES];
 pub const MUTUALLY_EXCLUSIVE_ROOT_KWS: [(&str, &str); 6] = [
@@ -71,8 +69,4 @@ pub fn is_any_kw(s: &str) -> bool {
 #[inline]
 pub fn is_root_kw(s: &str) -> bool {
     contains(&ROOT_KWS, s)
-}
-
-pub fn is_cat_kw(s: &str) -> bool {
-    contains(&CAT_KWS, s)
 }

--- a/crates/tighterror-build/src/parser/toml.rs
+++ b/crates/tighterror-build/src/parser/toml.rs
@@ -441,13 +441,6 @@ impl CategoryParser {
     }
 
     fn table(&self, mut t: Table) -> Result<CategorySpec, TbError> {
-        for k in t.keys() {
-            if !kws::is_cat_kw(k) {
-                log::error!("invalid CategoryObject attribute: {}", k);
-                return BAD_OBJECT_ATTRIBUTE.into();
-            }
-        }
-
         let mut cat_spec = CategorySpec::default();
 
         if let Some(v) = t.remove(kws::NAME) {
@@ -473,6 +466,11 @@ impl CategoryParser {
                 return BAD_OBJECT_ATTRIBUTE.into();
             }
             cat_spec.errors = ErrorsParser::value(v)?;
+        }
+
+        if let Some((k, _)) = t.into_iter().next() {
+            log::error!("invalid CategoryObject attribute: {}", k);
+            return BAD_OBJECT_ATTRIBUTE.into();
         }
 
         match self.0 {

--- a/crates/tighterror-build/src/parser/yaml.rs
+++ b/crates/tighterror-build/src/parser/yaml.rs
@@ -507,21 +507,6 @@ impl CategoryParser {
     }
 
     fn mapping(&self, mut m: Mapping) -> Result<CategorySpec, TbError> {
-        for k in m.keys() {
-            match k {
-                Value::String(s) => {
-                    if !kws::is_cat_kw(s) {
-                        error!("invalid CategoryObject attribute: {}", s);
-                        return BAD_OBJECT_ATTRIBUTE.into();
-                    }
-                }
-                ov => {
-                    error!("a Mapping key must be a String: deserialized {:?}", ov);
-                    return BAD_VALUE_TYPE.into();
-                }
-            }
-        }
-
         let mut cat_spec = CategorySpec::default();
 
         if let Some(v) = m.remove(kws::NAME) {
@@ -547,6 +532,12 @@ impl CategoryParser {
                 return BAD_OBJECT_ATTRIBUTE.into();
             }
             cat_spec.errors = ErrorsParser::value(v)?;
+        }
+
+        if let Some((k, _)) = m.into_iter().next() {
+            let key = v2key(k)?;
+            error!("invalid CategoryObject attribute: {}", key);
+            return BAD_OBJECT_ATTRIBUTE.into();
         }
 
         match self.0 {


### PR DESCRIPTION
Instead of iterating object attributes and matching them against every possible object keyword remove and parse known keywords first and only then check if there are any remaining attributes.

This way is faster because every removed attribute shortens the lookup and removal time for following attributes.