### PR TITLE
tb: yaml: fix `v2key` return code when mapping key type isn't a string

### DIFF
--- a/crates/tighterror-build/src/parser/yaml.rs
+++ b/crates/tighterror-build/src/parser/yaml.rs
@@ -624,7 +624,7 @@ fn v2key(v: Value) -> Result<String, TbError> {
         Value::String(s) => s,
         ov => {
             error!("a Mapping key must be a String: deserialized {:?}", ov);
-            return BAD_VALUE_TYPE.into();
+            return BAD_KEYWORD_TYPE.into();
         }
     };
 


### PR DESCRIPTION
The correct return code is BAD_KEYWORD_TYPE and not BAD_VALUE_TYPE.