### PR TITLE
tb: add a casing test-case

### DIFF
--- a/crates/tighterror-build/src/common/casing.rs
+++ b/crates/tighterror-build/src/common/casing.rs
@@ -24,6 +24,7 @@ mod testing {
             ("MyErr1", UpperSnake, UpperSnake, "MYERR1"),
             ("MyErr1", UpperCamel, UpperSnake, "MY_ERR_1"),
             ("MY_ERR1", UpperSnake, UpperCamel, "MyErr1"),
+            ("MY_ERR", UpperCamel, UpperCamel, "My_err"),
         ];
 
         for c in cases {


### PR DESCRIPTION
To explicitly show the conversion end result from UpperCamel to UpperCamel when the string's actual case is UPPER_SNAKE.

Specifically, the underscore is left there as a normal character and lowerUpper boundary doesn't kick-in to detect ERR as a separate word. So, the whole result appears as a single word.