### PR TITLE
tb: disallow underscore in UpperCamel case identifiers

### DIFF
--- a/crates/tighterror-build/src/parser/helpers.rs
+++ b/crates/tighterror-build/src/parser/helpers.rs
@@ -8,11 +8,16 @@ use convert_case::Case;
 use regex::Regex;
 use std::collections::HashSet;
 
-pub fn check_ident_chars(ident: &str, desc: &str) -> Result<(), TbError> {
-    let rg = Regex::new(r"^[A-Za-z0-9_]+$").unwrap();
+fn check_ident_chars(ident: &str, desc: &str, case: Case) -> Result<(), TbError> {
+    let rgs = match case {
+        Case::Pascal | Case::UpperCamel => r"^[A-Za-z0-9]+$",
+        _ => r"^[A-Za-z0-9_]+$",
+    };
+    let rg = Regex::new(rgs).unwrap();
     if !rg.is_match(ident) {
         log::error!(
-            "`{desc}` contains unsupported characters. Only [A-Za-z0-9_] are allowed: {ident}",
+            "`{desc}` contains unsupported characters. \
+            Only {rgs} is allowed with {case:?} case: {ident}",
         );
         BAD_IDENTIFIER_CHARACTERS.into()
     } else {
@@ -26,7 +31,7 @@ fn check_ident(ident: &str, desc: &str, case: Case) -> Result<(), TbError> {
         return EMPTY_IDENTIFIER.into();
     }
 
-    check_ident_chars(ident, desc)?;
+    check_ident_chars(ident, desc, case)?;
 
     if !casing::is_case(ident, case) {
         log::error!(

--- a/crates/tighterror-build/src/parser/toml/test_toml_parser.rs
+++ b/crates/tighterror-build/src/parser/toml/test_toml_parser.rs
@@ -22,7 +22,7 @@ const BAD_BOOLEANS: [(&str, TbErrorKind); 8] = [
     ("False", BAD_TOML),
     ("no", BAD_TOML),
 ];
-const BAD_IDENTS: [(&str, TbErrorKind); 7] = [
+const BAD_IDENTS: [(&str, TbErrorKind); 8] = [
     ("\"notUpperCamelCase\"", BAD_IDENTIFIER_CASE),
     ("\"With Spaces\"", BAD_IDENTIFIER_CHARACTERS),
     ("\"\"", EMPTY_IDENTIFIER),
@@ -30,6 +30,7 @@ const BAD_IDENTS: [(&str, TbErrorKind); 7] = [
     ("\" PaddedWithSpaces  \"", BAD_IDENTIFIER_CHARACTERS),
     ("\"Disallowed-Character-\"", BAD_IDENTIFIER_CHARACTERS),
     ("\"null\"", BAD_IDENTIFIER_CASE),
+    ("\"With_Underscore\"", BAD_IDENTIFIER_CHARACTERS),
 ];
 
 #[test]

--- a/crates/tighterror-build/src/parser/yaml/test_yaml_parser.rs
+++ b/crates/tighterror-build/src/parser/yaml/test_yaml_parser.rs
@@ -18,7 +18,7 @@ const GOOD_BOOLEANS: [(&str, bool); 4] = [
     ("False", false),
 ];
 const BAD_BOOLEANS: [&str; 5] = ["yes", "tr ue", "1", "on", "null"];
-const BAD_IDENTS: [(&str, TbErrorKind); 7] = [
+const BAD_IDENTS: [(&str, TbErrorKind); 8] = [
     ("notUpperCamelCase", BAD_IDENTIFIER_CASE),
     ("With Spaces", BAD_IDENTIFIER_CHARACTERS),
     ("\"\"", EMPTY_IDENTIFIER),
@@ -26,6 +26,7 @@ const BAD_IDENTS: [(&str, TbErrorKind); 7] = [
     ("\" PaddedWithSpaces  \"", BAD_IDENTIFIER_CHARACTERS),
     ("Disallowed-Character-", BAD_IDENTIFIER_CHARACTERS),
     ("null", BAD_VALUE_TYPE),
+    ("With_Underscore", BAD_IDENTIFIER_CHARACTERS),
 ];
 
 #[test]


### PR DESCRIPTION
Previously `check_ident_chars` was unaware of the casing of an identifier, allowing all of `[A-Za-z0-9_]` characters in all identifiers. However, UpperCamel case identifiers, e.g. a struct name, shouldn't be delimited by underscore. `convert_case` treats underscore as a regular character when checking compliance with UpperCamel case. Hence, it is better to reject underscore when checking the identifier characters.