### PR TITLE
tb: add name collisions check

### DIFF
--- a/crates/tighterror-build/src/errors.rs
+++ b/crates/tighterror-build/src/errors.rs
@@ -258,7 +258,8 @@ mod _n {
         pub(crate) const MUTUALLY_EXCLUSIVE_KEYWORDS: &str = "MUTUALLY_EXCLUSIVE_KEYWORDS";
         pub(crate) const NON_UNIQUE_NAME: &str = "NON_UNIQUE_NAME";
         pub(crate) const SPEC_FILE_NOT_FOUND: &str = "SPEC_FILE_NOT_FOUND";
-        pub static A: [&str; 18] = [
+        pub(crate) const NAME_COLLISION: &str = "NAME_COLLISION";
+        pub static A: [&str; 19] = [
             BAD_IDENTIFIER_CHARACTERS,
             BAD_IDENTIFIER_CASE,
             BAD_KEYWORD_TYPE,
@@ -277,6 +278,7 @@ mod _n {
             MUTUALLY_EXCLUSIVE_KEYWORDS,
             NON_UNIQUE_NAME,
             SPEC_FILE_NOT_FOUND,
+            NAME_COLLISION,
         ];
     }
 
@@ -329,7 +331,8 @@ mod _d {
             "Specification contains mutually exclusive keywords.";
         const NON_UNIQUE_NAME: &str = "A name is not unique.";
         const SPEC_FILE_NOT_FOUND: &str = "Specification file couldn't be found.";
-        pub static A: [&str; 18] = [
+        const NAME_COLLISION: &str = "Collision of names between different items.";
+        pub static A: [&str; 19] = [
             BAD_IDENTIFIER_CHARACTERS,
             BAD_IDENTIFIER_CASE,
             BAD_KEYWORD_TYPE,
@@ -348,6 +351,7 @@ mod _d {
             MUTUALLY_EXCLUSIVE_KEYWORDS,
             NON_UNIQUE_NAME,
             SPEC_FILE_NOT_FOUND,
+            NAME_COLLISION,
         ];
     }
 
@@ -384,7 +388,7 @@ mod _p {
     pub const CAT_BITS: usize = 1;
     pub const CAT_MAX: R = 1;
     pub const VAR_MASK: R = 31;
-    pub static VAR_MAXES: [R; 2] = [17, 8];
+    pub static VAR_MAXES: [R; 2] = [18, 8];
     pub const CAT_MASK: R = 32;
     pub const VAR_BITS: usize = 5;
     const _: () = assert!(KIND_BITS <= R::BITS as usize);
@@ -472,6 +476,9 @@ pub mod kind {
 
         /// Specification file couldn't be found.
         pub const SPEC_FILE_NOT_FOUND: EK = EK::new(c::PARSER, 17);
+
+        /// Collision of names between different items.
+        pub const NAME_COLLISION: EK = EK::new(c::PARSER, 18);
     }
 
     /// Coder category error kind constants.

--- a/crates/tighterror-build/src/parser/helpers.rs
+++ b/crates/tighterror-build/src/parser/helpers.rs
@@ -3,6 +3,7 @@ use crate::{
     common::casing,
     errors::{kind::parser::*, TbError},
     parser::kws,
+    spec::ModuleSpec,
 };
 use convert_case::Case;
 use regex::Regex;
@@ -157,4 +158,27 @@ where
     I: IntoIterator<Item = &'a str>,
 {
     check_name_uniqueness("module", iter)
+}
+
+pub fn check_name_collisions(m: &ModuleSpec) -> Result<(), TbError> {
+    check_struct_names_collision(m)?;
+    Ok(())
+}
+
+pub fn check_struct_names_collision(m: &ModuleSpec) -> Result<(), TbError> {
+    let err_name = m.err_name();
+    let err_cat_name = m.err_cat_name();
+    let err_kind_name = m.err_kind_name();
+
+    if err_name == err_cat_name {
+        log::error!("error name equals error category name: {err_name}");
+        return NAME_COLLISION.into();
+    } else if err_name == err_kind_name {
+        log::error!("error name equals error kind name: {err_name}");
+        return NAME_COLLISION.into();
+    } else if err_cat_name == err_kind_name {
+        log::error!("error category name equals error kind name: {err_cat_name}");
+        return NAME_COLLISION.into();
+    }
+    Ok(())
 }

--- a/crates/tighterror-build/src/parser/toml.rs
+++ b/crates/tighterror-build/src/parser/toml.rs
@@ -109,6 +109,7 @@ impl TomlParser {
             if m.flat_kinds.unwrap_or(DEFAULT_FLAT_KINDS) {
                 check_module_error_name_uniqueness(m.errors_iter().map(|e| e.name.as_str()))?;
             }
+            check_name_collisions(m)?;
         }
 
         Ok(spec)

--- a/crates/tighterror-build/src/parser/yaml.rs
+++ b/crates/tighterror-build/src/parser/yaml.rs
@@ -109,6 +109,7 @@ impl YamlParser {
             if m.flat_kinds.unwrap_or(DEFAULT_FLAT_KINDS) {
                 check_module_error_name_uniqueness(m.errors_iter().map(|e| e.name.as_str()))?;
             }
+            check_name_collisions(m)?;
         }
 
         Ok(spec)

--- a/crates/tighterror-build/tighterror.yaml
+++ b/crates/tighterror-build/tighterror.yaml
@@ -31,6 +31,7 @@ categories:
       - MUTUALLY_EXCLUSIVE_KEYWORDS: Specification contains mutually exclusive keywords.
       - NON_UNIQUE_NAME: A name is not unique.
       - SPEC_FILE_NOT_FOUND: Specification file couldn't be found.
+      - NAME_COLLISION: Collision of names between different items.
 
   - name: Coder
     doc: Coder errors category.


### PR DESCRIPTION
This commit adds another parser check to verify that custom struct names do not collide. Till now the check only compared names to implicit module-level identifiers only.

This commit is also done in preparation for checking collisions between variant type names and module-level structs.