### PR TITLE
tb: add support for Variant Types

### DIFF
--- a/crates/tighterror-build/src/coder/formatter.rs
+++ b/crates/tighterror-build/src/coder/formatter.rs
@@ -27,6 +27,7 @@ fn add_newlines(file: String) -> String {
         r"^[[:space:]]*const fn",
         r"^[[:space:]]*pub fn",
         r"^[[:space:]]*#\[.*\]$",
+        r"^[[:space:]]*impl",
     ])
     .unwrap();
     let rg_post = RegexSet::new([

--- a/crates/tighterror-build/src/coder/generator/helpers.rs
+++ b/crates/tighterror-build/src/coder/generator/helpers.rs
@@ -73,3 +73,11 @@ pub fn tests_mod_ident() -> Ident {
 pub fn categories_mod_ident() -> Ident {
     format_ident!("{}", idents::CATEGORY_CONSTS_MOD)
 }
+
+pub fn variants_mod_ident() -> Ident {
+    format_ident!("{}", idents::VARIANTS_MOD)
+}
+
+pub fn types_mod_ident() -> Ident {
+    format_ident!("{}", idents::TYPES_MOD)
+}

--- a/crates/tighterror-build/src/coder/idents.rs
+++ b/crates/tighterror-build/src/coder/idents.rs
@@ -7,9 +7,11 @@ pub const ERROR_DISPLAYS_MOD: &str = "_d";
 pub const PRIVATE_MOD: &str = "_p";
 pub const CATEGORY_CONSTS_MOD: &str = "category";
 pub const ERROR_KINDS_MOD: &str = "kind";
+pub const VARIANTS_MOD: &str = "variant";
+pub const TYPES_MOD: &str = "types"; // singular `type` is rust-reserved
 pub const TESTS_MOD: &str = "test";
 
-const ROOT_LEVEL: [&str; 10] = [
+const ROOT_LEVEL: [&str; 11] = [
     ERROR,
     ERROR_CATEGORY,
     ERROR_KIND,
@@ -19,6 +21,7 @@ const ROOT_LEVEL: [&str; 10] = [
     PRIVATE_MOD,
     CATEGORY_CONSTS_MOD,
     ERROR_KINDS_MOD,
+    VARIANTS_MOD,
     TESTS_MOD,
 ];
 

--- a/crates/tighterror-build/src/errors.rs
+++ b/crates/tighterror-build/src/errors.rs
@@ -309,29 +309,31 @@ mod _n {
 }
 
 mod _d {
-    mod parser {
-        const BAD_IDENTIFIER_CHARACTERS: &str = "Identifier contains unsupported characters.";
-        const BAD_IDENTIFIER_CASE: &str = "Identifier is specified in an unsupported case.";
-        const BAD_KEYWORD_TYPE: &str = "Specification keyword is not a String.";
-        const BAD_MODULE_IDENTIFIER: &str = "Identifier is not valid on module-level.";
-        const BAD_NAME: &str = "Invalid name.";
-        const BAD_OBJECT_ATTRIBUTE: &str = "An object attribute is invalid.";
-        const BAD_SPEC_FILE_EXTENSION: &str =
+    pub(crate) mod parser {
+        pub(crate) const BAD_IDENTIFIER_CHARACTERS: &str =
+            "Identifier contains unsupported characters.";
+        pub(crate) const BAD_IDENTIFIER_CASE: &str =
+            "Identifier is specified in an unsupported case.";
+        pub(crate) const BAD_KEYWORD_TYPE: &str = "Specification keyword is not a String.";
+        pub(crate) const BAD_MODULE_IDENTIFIER: &str = "Identifier is not valid on module-level.";
+        pub(crate) const BAD_NAME: &str = "Invalid name.";
+        pub(crate) const BAD_OBJECT_ATTRIBUTE: &str = "An object attribute is invalid.";
+        pub(crate) const BAD_SPEC_FILE_EXTENSION: &str =
             "Specification filename extension is not supported or is missing.";
-        const BAD_TOML: &str = "TOML deserialization has failed.";
-        const BAD_ROOT_LEVEL_KEYWORD: &str =
+        pub(crate) const BAD_TOML: &str = "TOML deserialization has failed.";
+        pub(crate) const BAD_ROOT_LEVEL_KEYWORD: &str =
             "Specification contains an invalid root-level keyword.";
-        const BAD_VALUE_TYPE: &str = "Specification value type is invalid.";
-        const BAD_YAML: &str = "YAML deserialization has failed.";
-        const EMPTY_IDENTIFIER: &str = "An identifier cannot be an empty string.";
-        const EMPTY_LIST: &str = "Empty list of objects is not allowed.";
-        const FAILED_TO_OPEN_SPEC_FILE: &str = "Specification file couldn't be opened.";
-        const MISSING_ATTRIBUTE: &str = "Specification lacks a mandatory attribute.";
-        const MUTUALLY_EXCLUSIVE_KEYWORDS: &str =
+        pub(crate) const BAD_VALUE_TYPE: &str = "Specification value type is invalid.";
+        pub(crate) const BAD_YAML: &str = "YAML deserialization has failed.";
+        pub(crate) const EMPTY_IDENTIFIER: &str = "An identifier cannot be an empty string.";
+        pub(crate) const EMPTY_LIST: &str = "Empty list of objects is not allowed.";
+        pub(crate) const FAILED_TO_OPEN_SPEC_FILE: &str = "Specification file couldn't be opened.";
+        pub(crate) const MISSING_ATTRIBUTE: &str = "Specification lacks a mandatory attribute.";
+        pub(crate) const MUTUALLY_EXCLUSIVE_KEYWORDS: &str =
             "Specification contains mutually exclusive keywords.";
-        const NON_UNIQUE_NAME: &str = "A name is not unique.";
-        const SPEC_FILE_NOT_FOUND: &str = "Specification file couldn't be found.";
-        const NAME_COLLISION: &str = "Collision of names between different items.";
+        pub(crate) const NON_UNIQUE_NAME: &str = "A name is not unique.";
+        pub(crate) const SPEC_FILE_NOT_FOUND: &str = "Specification file couldn't be found.";
+        pub(crate) const NAME_COLLISION: &str = "Collision of names between different items.";
         pub static A: [&str; 19] = [
             BAD_IDENTIFIER_CHARACTERS,
             BAD_IDENTIFIER_CASE,
@@ -355,17 +357,17 @@ mod _d {
         ];
     }
 
-    mod coder {
-        const CATEGORY_REQUIRED: &str = "At least one category must be defined.";
-        const ERROR_REQUIRED: &str = "At least one error must be defined.";
-        const FAILED_TO_PARSE_TOKENS: &str = "Generated code tokens couldn't be parsed.";
-        const FAILED_TO_READ_OUTPUT_FILE: &str = "Output file couldn't be read.";
-        const FAILED_TO_WRITE_OUTPUT_FILE: &str = "Output file couldn't be written.";
-        const RUSTFMT_FAILED: &str = "Rustfmt tool exited with an error.";
-        const RUSTFMT_NOT_FOUND: &str = "Rustfmt tool isn't found.";
-        const TOO_MANY_BITS: &str =
+    pub(crate) mod coder {
+        pub(crate) const CATEGORY_REQUIRED: &str = "At least one category must be defined.";
+        pub(crate) const ERROR_REQUIRED: &str = "At least one error must be defined.";
+        pub(crate) const FAILED_TO_PARSE_TOKENS: &str = "Generated code tokens couldn't be parsed.";
+        pub(crate) const FAILED_TO_READ_OUTPUT_FILE: &str = "Output file couldn't be read.";
+        pub(crate) const FAILED_TO_WRITE_OUTPUT_FILE: &str = "Output file couldn't be written.";
+        pub(crate) const RUSTFMT_FAILED: &str = "Rustfmt tool exited with an error.";
+        pub(crate) const RUSTFMT_NOT_FOUND: &str = "Rustfmt tool isn't found.";
+        pub(crate) const TOO_MANY_BITS: &str =
             "The number of required bits exceeds the largest supported type u64.";
-        const OUTPUT_PATH_NOT_DIRECTORY: &str = "Output path is not a directory.";
+        pub(crate) const OUTPUT_PATH_NOT_DIRECTORY: &str = "Output path is not a directory.";
         pub static A: [&str; 9] = [
             CATEGORY_REQUIRED,
             ERROR_REQUIRED,
@@ -394,6 +396,7 @@ mod _p {
     const _: () = assert!(KIND_BITS <= R::BITS as usize);
     const _: () = assert!(CAT_BITS <= usize::BITS as usize);
     pub(super) struct Ident<'a>(pub(super) &'a str);
+
     impl<'a> core::fmt::Debug for Ident<'a> {
         #[inline]
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/tighterror-build/src/parser/kws.rs
+++ b/crates/tighterror-build/src/parser/kws.rs
@@ -20,6 +20,7 @@ pub const MODULES: &str = "modules";
 pub const CATEGORY: &str = "category";
 pub const CATEGORIES: &str = "categories";
 pub const FLAT_KINDS: &str = "flat_kinds";
+pub const VARIANT_TYPE: &str = "variant_type";
 
 pub const ROOT_KWS: [&str; 6] = [MAIN, ERRORS, MODULE, MODULES, CATEGORY, CATEGORIES];
 pub const REQUIRED_ROOT_KWS: [&str; 3] = [ERRORS, CATEGORIES, MODULES];
@@ -31,7 +32,7 @@ pub const MUTUALLY_EXCLUSIVE_ROOT_KWS: [(&str, &str); 6] = [
     (CATEGORIES, MODULES),
     (MODULE, MODULES),
 ];
-pub const ALL_KWS: [&str; 22] = [
+pub const ALL_KWS: [&str; 23] = [
     ERR_CAT_DOC,
     DISPLAY,
     DOC,
@@ -54,6 +55,7 @@ pub const ALL_KWS: [&str; 22] = [
     CATEGORY,
     CATEGORIES,
     FLAT_KINDS,
+    VARIANT_TYPE,
 ];
 
 #[inline]

--- a/crates/tighterror-build/src/parser/toml.rs
+++ b/crates/tighterror-build/src/parser/toml.rs
@@ -276,6 +276,10 @@ impl ModuleParser {
             mod_spec.flat_kinds = Some(v2bool(v, kws::FLAT_KINDS)?);
         }
 
+        if let Some(v) = t.remove(kws::VARIANT_TYPE) {
+            mod_spec.oes.variant_type = Some(v2bool(v, kws::VARIANT_TYPE)?);
+        }
+
         if let Some((k, _)) = t.into_iter().next() {
             let key = check_key(&k)?;
             log::error!("invalid ModuleObject attribute: {}", key);
@@ -410,6 +414,24 @@ impl ErrorParser {
             err_spec.oes.doc_from_display = Some(v2bool(v, kws::DOC_FROM_DISPLAY)?);
         }
 
+        if let Some(v) = t.remove(kws::VARIANT_TYPE) {
+            match v {
+                Value::Boolean(b) => err_spec.oes.variant_type = Some(b),
+                Value::String(s) => {
+                    check_variant_type_name(&s)?;
+                    err_spec.oes.variant_type = Some(true);
+                    err_spec.variant_type_name = Some(s);
+                }
+                _ => {
+                    log::error!(
+                        "ErrorObject::{} must be a String or a Boolean: deserialized {v:?}",
+                        kws::VARIANT_TYPE
+                    );
+                    return BAD_VALUE_TYPE.into();
+                }
+            }
+        }
+
         if let Some((k, _)) = t.into_iter().next() {
             let key = check_key(&k)?;
             log::error!("invalid ErrorObject attribute: {}", key);
@@ -467,6 +489,10 @@ impl CategoryParser {
                 return BAD_OBJECT_ATTRIBUTE.into();
             }
             cat_spec.errors = ErrorListParser::value(v)?;
+        }
+
+        if let Some(v) = t.remove(kws::VARIANT_TYPE) {
+            cat_spec.oes.variant_type = Some(v2bool(v, kws::VARIANT_TYPE)?);
         }
 
         if let Some((k, _)) = t.into_iter().next() {

--- a/crates/tighterror-build/src/parser/yaml.rs
+++ b/crates/tighterror-build/src/parser/yaml.rs
@@ -285,6 +285,10 @@ impl ModuleParser {
             mod_spec.flat_kinds = Some(v2bool(v, kws::FLAT_KINDS)?);
         }
 
+        if let Some(v) = m.remove(kws::VARIANT_TYPE) {
+            mod_spec.oes.variant_type = Some(v2bool(v, kws::VARIANT_TYPE)?);
+        }
+
         if let Some((k, _)) = m.into_iter().next() {
             let key = v2key(k)?;
             error!("invalid ModuleObject attribute: {}", key);
@@ -476,6 +480,24 @@ impl ErrorParser {
             err_spec.oes.doc_from_display = Some(v2bool(v, kws::DOC_FROM_DISPLAY)?);
         }
 
+        if let Some(v) = m.remove(kws::VARIANT_TYPE) {
+            match v {
+                Value::Bool(b) => err_spec.oes.variant_type = Some(b),
+                Value::String(s) => {
+                    check_variant_type_name(&s)?;
+                    err_spec.oes.variant_type = Some(true);
+                    err_spec.variant_type_name = Some(s);
+                }
+                _ => {
+                    error!(
+                        "ErrorObject::{} must be a String or a Bool: deserialized {v:?}",
+                        kws::VARIANT_TYPE
+                    );
+                    return BAD_VALUE_TYPE.into();
+                }
+            }
+        }
+
         if let Some((k, _)) = m.into_iter().next() {
             let key = v2key(k)?;
             error!("invalid ErrorObject attribute: {}", key);
@@ -533,6 +555,10 @@ impl CategoryParser {
                 return BAD_OBJECT_ATTRIBUTE.into();
             }
             cat_spec.errors = ErrorListParser::value(v)?;
+        }
+
+        if let Some(v) = m.remove(kws::VARIANT_TYPE) {
+            cat_spec.oes.variant_type = Some(v2bool(v, kws::VARIANT_TYPE)?);
         }
 
         if let Some((k, _)) = m.into_iter().next() {

--- a/crates/tighterror-build/src/parser/yaml/test_yaml_parser.rs
+++ b/crates/tighterror-build/src/parser/yaml/test_yaml_parser.rs
@@ -110,6 +110,7 @@ fn test_err_doc_from_display() {
             name: "TEST_ERROR".into(),
             oes: OverridableErrorSpec {
                 doc_from_display: Some(good.1),
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -253,7 +254,9 @@ errors:
         display: Some("An error description.".into()),
         oes: OverridableErrorSpec {
             doc_from_display: Some(false),
+            ..Default::default()
         },
+        ..Default::default()
     };
     let spec = spec_from_err(err);
     let res = YamlParser::parse_str(s).unwrap();
@@ -293,7 +296,9 @@ errors:
         display: Some("An error description.".into()),
         oes: OverridableErrorSpec {
             doc_from_display: Some(false),
+            ..Default::default()
         },
+        ..Default::default()
     };
     let err4 = ErrorSpec {
         name: "ERR2".into(),
@@ -305,6 +310,7 @@ errors:
         display: Some("A third one.".into()),
         oes: OverridableErrorSpec {
             doc_from_display: Some(true),
+            ..Default::default()
         },
         ..Default::default()
     };
@@ -360,6 +366,7 @@ fn test_module_doc_from_display() {
         let module = ModuleSpec {
             oes: OverridableErrorSpec {
                 doc_from_display: Some(good.1),
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -993,6 +1000,7 @@ fn test_category_doc_from_display() {
             name: IMPLICIT_CATEGORY_NAME.into(),
             oes: OverridableErrorSpec {
                 doc_from_display: Some(good.1),
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1154,6 +1162,7 @@ categories:
         doc: Some("First category.".into()),
         oes: OverridableErrorSpec {
             doc_from_display: Some(false),
+            ..Default::default()
         },
         errors: vec![ErrorSpec {
             name: "DUMMY_ERR".into(),
@@ -1165,6 +1174,7 @@ categories:
         name: "Cat2".into(),
         oes: OverridableErrorSpec {
             doc_from_display: Some(true),
+            ..Default::default()
         },
         errors: vec![ErrorSpec {
             name: "DUMMY_ERR2".into(),
@@ -1481,4 +1491,112 @@ modules:
           - ANOTHER_ERR
 "#;
     assert!(YamlParser::parse_str(s).is_ok());
+}
+
+#[test]
+fn test_error_variant_type() {
+    log_init();
+
+    let s = r#"
+---
+errors:
+    - name: MY_ERR
+      variant_type: MyErr
+"#;
+
+    let err = ErrorSpec {
+        name: "MY_ERR".into(),
+        oes: OverridableErrorSpec {
+            variant_type: Some(true),
+            ..Default::default()
+        },
+        variant_type_name: Some("MyErr".into()),
+        ..Default::default()
+    };
+    let spec = spec_from_err(err);
+    let res = YamlParser::parse_str(s).unwrap();
+    assert_eq!(res, spec);
+
+    for val in [true, false] {
+        let s = format!("---\nerrors:\n  - name: MY_ERR\n    variant_type: {val}");
+        let err = ErrorSpec {
+            name: "MY_ERR".into(),
+            oes: OverridableErrorSpec {
+                variant_type: Some(val),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let spec = spec_from_err(err);
+        let res = YamlParser::parse_str(&s).unwrap();
+        assert_eq!(res, spec);
+    }
+}
+
+#[test]
+fn test_error_variant_type_bad_name() {
+    log_init();
+
+    let test_cases = &[
+        ("MY_ERR", BAD_IDENTIFIER_CHARACTERS),
+        ("my_err", BAD_IDENTIFIER_CHARACTERS),
+        ("myErr", BAD_IDENTIFIER_CASE),
+        ("myerr", BAD_IDENTIFIER_CASE),
+    ];
+
+    for tc in test_cases {
+        let s = format!("---\nerrors:\n  - name: MY_ERR\n    variant_type: {}", tc.0);
+        assert_eq!(YamlParser::parse_str(&s).unwrap_err().kind(), tc.1);
+    }
+}
+
+#[test]
+fn test_category_variant_type() {
+    log_init();
+
+    for val in [true, false] {
+        let s = format!("---\ncategory:\n  variant_type: {val}\nerrors:\n  - DUMMY_ERR");
+        let cat = CategorySpec {
+            name: "General".into(),
+            oes: OverridableErrorSpec {
+                variant_type: Some(val),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let spec = spec_from_category(cat);
+        let res = YamlParser::parse_str(&s).unwrap();
+        assert_eq!(res, spec);
+    }
+
+    for bad in BAD_BOOLEANS {
+        let s = format!("---\ncategory:\n  variant_type: {bad}\nerrors:\n  - DUMMY_ERR");
+        let res = YamlParser::parse_str(&s);
+        assert_eq!(res.unwrap_err().kind(), BAD_VALUE_TYPE);
+    }
+}
+
+#[test]
+fn test_module_variant_type() {
+    log_init();
+
+    for val in [true, false] {
+        let s = format!("---\nmodule:\n  variant_type: {val}\nerrors:\n  - DUMMY_ERR");
+        let module = ModuleSpec {
+            oes: OverridableErrorSpec {
+                variant_type: Some(val),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let spec = spec_from_module(module);
+        let res = YamlParser::parse_str(&s).unwrap();
+        assert_eq!(res, spec);
+    }
+
+    for bad in BAD_BOOLEANS {
+        let s = format!("---\nmodule:\n  variant_type: {bad}\nerrors:\n  - DUMMY_ERR");
+        let res = YamlParser::parse_str(&s);
+        assert_eq!(res.unwrap_err().kind(), BAD_VALUE_TYPE);
+    }
 }

--- a/crates/tighterror-build/src/spec/definitions.rs
+++ b/crates/tighterror-build/src/spec/definitions.rs
@@ -18,3 +18,4 @@ pub const DEFAULT_UPDATE_MODE: bool = false;
 pub const DEFAULT_NO_STD: bool = false;
 pub const DEFAULT_FLAT_KINDS: bool = false;
 pub const DEFAULT_SEPARATE_FILES: bool = false;
+pub const DEFAULT_VARIANT_TYPE: bool = false;

--- a/crates/tighterror-build/src/spec/error.rs
+++ b/crates/tighterror-build/src/spec/error.rs
@@ -1,6 +1,10 @@
+use crate::common::casing;
+use convert_case::Case;
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OverridableErrorSpec {
     pub doc_from_display: Option<bool>,
+    pub variant_type: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -8,5 +12,16 @@ pub struct ErrorSpec {
     pub name: String,
     pub display: Option<String>,
     pub doc: Option<String>,
+    pub variant_type_name: Option<String>,
     pub oes: OverridableErrorSpec,
+}
+
+impl ErrorSpec {
+    pub fn variant_type_name(&self) -> String {
+        if let Some(ref vtn) = self.variant_type_name {
+            vtn.clone()
+        } else {
+            casing::convert_case(&self.name, Case::UpperSnake, Case::UpperCamel)
+        }
+    }
 }

--- a/crates/tighterror-build/src/spec/module.rs
+++ b/crates/tighterror-build/src/spec/module.rs
@@ -144,6 +144,36 @@ impl ModuleSpec {
     pub fn flat_kinds(&self) -> bool {
         self.flat_kinds.unwrap_or(DEFAULT_FLAT_KINDS)
     }
+
+    pub fn has_variant_types(&self) -> bool {
+        self.categories
+            .iter()
+            .any(|c| self.cat_has_variant_types(c))
+    }
+
+    pub fn has_display_variant_types(&self) -> bool {
+        self.categories
+            .iter()
+            .any(|c| self.cat_has_display_variant_types(c))
+    }
+
+    pub fn cat_has_variant_types(&self, c: &CategorySpec) -> bool {
+        c.errors.iter().any(|e| self.err_has_variant_type(c, e))
+    }
+
+    pub fn cat_has_display_variant_types(&self, c: &CategorySpec) -> bool {
+        c.errors
+            .iter()
+            .any(|e| e.display.is_some() && self.err_has_variant_type(c, e))
+    }
+
+    pub fn err_has_variant_type(&self, c: &CategorySpec, e: &ErrorSpec) -> bool {
+        e.oes
+            .variant_type
+            .or(c.oes.variant_type)
+            .or(self.oes.variant_type)
+            .unwrap_or(DEFAULT_VARIANT_TYPE)
+    }
 }
 
 pub struct ModuleSpecErrorIter<'a> {

--- a/crates/tighterror-build/tests/multiple_modules/src/lib.rs
+++ b/crates/tighterror-build/tests/multiple_modules/src/lib.rs
@@ -14,9 +14,22 @@ pub mod internal_errors {
     include!(concat!(env!("OUT_DIR"), "/internal_errors.rs"));
 }
 
+/// FlatKinds module.
+pub mod flat_kinds_mod {
+    include!(concat!(env!("OUT_DIR"), "/flat_kinds_mod.rs"));
+}
+
+/// FlatKinds module without display attributes.
+pub mod flat_kinds_mod_without_display {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/flat_kinds_mod_without_display.rs"
+    ));
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{errors, internal_errors};
+    use crate::{errors, flat_kinds_mod, internal_errors};
 
     #[test]
     fn test_kind_constants_are_placed_in_different_modules() {
@@ -27,6 +40,22 @@ mod tests {
         assert_ne!(
             internal_errors::kind::parser::BAD_FILE,
             internal_errors::kind::processor::BAD_FILE,
+        );
+    }
+
+    #[test]
+    fn test_variant_types() {
+        assert_eq!(
+            format!("{}", flat_kinds_mod::variant::types::CatOneErrOne),
+            "CatOne error #1"
+        );
+        assert_eq!(
+            format!("{}", flat_kinds_mod::variant::types::CatOneWithoutDisplay),
+            "CatOneWithoutDisplay"
+        );
+        assert_eq!(
+            format!("{}", flat_kinds_mod::variant::types::CatTwoSpecial),
+            "CatTwoSpecial"
         );
     }
 }

--- a/crates/tighterror-build/tests/multiple_modules/tighterror.yaml
+++ b/crates/tighterror-build/tests/multiple_modules/tighterror.yaml
@@ -37,6 +37,10 @@ modules:
           - QUEUE_FULL: Processing queue is full.
           - name: WITHOUT_DISPLAY
             doc: An error without display string.
+            variant_type: true
+          - name: WITHOUT_DOC
+            display: An error without doc string.
+            variant_type: true
 
       - name: General
         doc: General errors category.
@@ -59,3 +63,48 @@ modules:
               let e: Error = BAD_ARG.into();
               ```
           - TIMEOUT: Operation timed out.
+
+  - name: flat_kinds_mod
+    flat_kinds: true
+    doc_from_display: true
+    variant_type: true
+    categories:
+      - name: CatOne
+        doc: "Category #1"
+        errors:
+          - CAT_ONE_ERR_ONE: "CatOne error #1"
+          - CAT_ONE_ERR_TWO: "CatOne error #2"
+          - name: CAT_ONE_WITHOUT_DISPLAY
+            doc: A CatOne error without display string.
+          - name: CAT_ONE_WITHOUT_DOC
+            display: An error without doc string.
+      - name: CatTwo
+        doc: "Category #2"
+        errors:
+          - CAT_TWO_ERR_ONE: "CatTwo error #1"
+          - CAT_TWO_ERR_TWO: "CatTwo error #2"
+          - name: CAT_TWO_WITHOUT_DISPLAY
+            doc: A CatTwo error without display string.
+            variant_type: CatTwoSpecial
+
+  - name: flat_kinds_mod_without_display
+    flat_kinds: true
+    variant_type: true
+    categories:
+      - name: CatOne
+        doc: "Category #1"
+        errors:
+          - name: CAT_ONE_ERR_ONE
+            doc: "CatOne error #1"
+          - name: CAT_ONE_ERR_TWO
+            doc: "CatOne error #2"
+      - name: CatTwo
+        doc: "Category #2"
+        errors:
+          - name: CAT_TWO_ERR_ONE
+            doc: "CatTwo error #1"
+          - name: CAT_TWO_ERR_TWO
+            doc: "CatTwo error #2"
+          - name: CAT_TWO_CUSTOM_NAME
+            doc: A CatTwo error without display string.
+            variant_type: CatTwoCustomVariantTypeName

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1322,3 +1322,6 @@ pub use error::*;
 
 mod location;
 pub use location::*;
+
+mod variant_type;
+pub use variant_type::*;

--- a/src/variant_type.rs
+++ b/src/variant_type.rs
@@ -1,0 +1,49 @@
+use crate::{Category, Kind};
+use core::fmt::{Debug, Display};
+
+/// The trait of variant types.
+pub trait VariantType: Clone + Debug + Display {
+    /// The underlying Rust type of error kind.
+    ///
+    /// A concrete builtin type, e.g., `u8`.
+    type R;
+
+    /// The error category concrete type.
+    type Category: Category<R = Self::R>;
+
+    /// The error kind concrete type.
+    type Kind: Kind<R = Self::R, Category = Self::Category>;
+
+    /// The error category of the variant type.
+    const CATEGORY: Self::Category;
+
+    /// The error kind of the variant type.
+    const KIND: Self::Kind;
+
+    /// The concrete type name.
+    const NAME: &'static str;
+
+    /// Returns the error category of the variant type.
+    ///
+    /// This is a convenience method that returns [CATEGORY](Self::CATEGORY).
+    #[inline]
+    fn category(&self) -> Self::Category {
+        Self::CATEGORY
+    }
+
+    /// Returns the error kind of the variant type.
+    ///
+    /// This is a convenience method that returns [KIND](Self::KIND).
+    #[inline]
+    fn kind(&self) -> Self::Kind {
+        Self::KIND
+    }
+
+    /// Returns the variant type name.
+    ///
+    /// This is a convenience method that returns [NAME](Self::NAME).
+    #[inline]
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+}


### PR DESCRIPTION
Variant Types are ZSTs created for error kinds. They are useful when a function has only a single error condition. In such cases returning a full-fledged Error may be excessive because that forces a caller to handle a non-exhaustive list of errors. With Variant Types the return code is exhaustive, making error handling simpler.

Note that Variant Types are marked `#[non_exhaustive]` to forbid their creation outside their origin crate. This doesn't affect a function that returns such type. A caller of such function still needs to handle only a single error.

Variant Types may be enhanced in future to contain custom fields. This will allow returning rich information about errors.

Variant Types are implicitly convertible to Kind and Error so propagating them through layers of abstraction is seamless as tighterror aims to be.