### PR TITLE
tb: fix `clippy::needless_lifetimes` warning

### DIFF
--- a/crates/tighterror-build/src/coder/generator/module.rs
+++ b/crates/tighterror-build/src/coder/generator/module.rs
@@ -135,7 +135,7 @@ impl<'a> ModuleGenerator<'a> {
     fn private_types(&self) -> TokenStream {
         quote! {
             pub(super) struct Ident<'a>(pub(super) &'a str);
-            impl<'a> core::fmt::Debug for Ident<'a> {
+            impl core::fmt::Debug for Ident<'_> {
                 #[inline]
                 fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     f.pad(self.0)

--- a/crates/tighterror-build/src/errors.rs
+++ b/crates/tighterror-build/src/errors.rs
@@ -397,7 +397,7 @@ mod _p {
     const _: () = assert!(CAT_BITS <= usize::BITS as usize);
     pub(super) struct Ident<'a>(pub(super) &'a str);
 
-    impl<'a> core::fmt::Debug for Ident<'a> {
+    impl core::fmt::Debug for Ident<'_> {
         #[inline]
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             f.pad(self.0)


### PR DESCRIPTION
Appeared since the release of v1.83.0-beta.1:

error: the following explicit lifetimes could be elided: 'a
   --> crates/tighterror-build/src/errors.rs:400:10
    |
400 |     impl<'a> core::fmt::Debug for Ident<'a> {
    |          ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
note: the lint level is defined here
   --> crates/tighterror-build/src/lib.rs:122:9
    |
122 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::needless_lifetimes)]` implied by `#[deny(warnings)]`
help: elide the lifetimes
    |
400 -     impl<'a> core::fmt::Debug for Ident<'a> {
400 +     impl core::fmt::Debug for Ident<'_> {
    |

error: could not compile `tighterror-build` (lib) due to 1 previous error
